### PR TITLE
fix flaky tests

### DIFF
--- a/src/test/java/org/snakeyaml/engine/issues/issue25/DumpToStringTest.java
+++ b/src/test/java/org/snakeyaml/engine/issues/issue25/DumpToStringTest.java
@@ -16,7 +16,7 @@ package org.snakeyaml.engine.issues.issue25;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.LinkedHashMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.snakeyaml.engine.v2.api.Dump;
@@ -30,7 +30,7 @@ public class DumpToStringTest {
   @Test
   @DisplayName("If Dump instance is called more then once then the results are not predictable.")
   void dumpToStringTwice() {
-    ConcurrentHashMap<String, Object> data = new ConcurrentHashMap<>();
+    LinkedHashMap<String, Object> data = new LinkedHashMap<>();
     DumpSettings dumpSettings = DumpSettings.builder().setDefaultFlowStyle(FlowStyle.BLOCK).build();
     Dump dump = new Dump(dumpSettings);
     class Something {
@@ -49,6 +49,7 @@ public class DumpToStringTest {
           e.getMessage());
     }
     String output = dump.dumpToString(data);
+    System.out.print("actual " + output);
     assertEquals("before: bla\n", output);
   }
 }

--- a/src/test/java/org/snakeyaml/engine/usecases/recursive/RecursiveMapTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/recursive/RecursiveMapTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -47,15 +47,15 @@ class RecursiveMapTest {
   @Test
   @DisplayName("Dump and Load map with recursive values")
   void loadRecursiveMap2() {
-    Map<String, Object> map1 = new HashMap<>();
+    Map<String, Object> map1 = new LinkedHashMap<>();
     map1.put("name", "first");
-    Map<String, Object> map2 = new HashMap<>();
+    Map<String, Object> map2 = new LinkedHashMap<>();
     map2.put("name", "second");
     map1.put("next", map2);
     map2.put("next", map1);
     Dump dump = new Dump(DumpSettings.builder().build());
     String output1 = dump.dumpToString(map1);
-    assertEquals("&id001\n" + "next:\n" + "  next: *id001\n" + "  name: second\n" + "name: first\n",
+    assertEquals("&id001\n" + "name: first\n" + "next:\n" + "  name: second\n" + "  next: *id001\n",
         output1);
 
     LoadSettings settings = LoadSettings.builder().build();

--- a/src/test/java/org/snakeyaml/engine/usecases/references/ReferencesTest.java
+++ b/src/test/java/org/snakeyaml/engine/usecases/references/ReferencesTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -36,18 +36,18 @@ public class ReferencesTest {
    * @return YAML to parse
    */
   private String createDump(int size) {
-    HashMap root = new HashMap();
-    HashMap s1, s2, t1, t2;
+    LinkedHashMap root = new LinkedHashMap();
+    LinkedHashMap s1, s2, t1, t2;
     s1 = root;
-    s2 = new HashMap();
+    s2 = new LinkedHashMap();
     /*
      * the time to parse grows very quickly SIZE -> time to parse in seconds 25 -> 1 26 -> 2 27 -> 3
      * 28 -> 8 29 -> 13 30 -> 28 31 -> 52 32 -> 113 33 -> 245 34 -> 500
      */
     for (int i = 0; i < size; i++) {
 
-      t1 = new HashMap();
-      t2 = new HashMap();
+      t1 = new LinkedHashMap();
+      t2 = new LinkedHashMap();
       t1.put("foo", "1");
       t2.put("bar", "2");
 
@@ -62,7 +62,7 @@ public class ReferencesTest {
 
     // this is VERY BAD code
     // the map has itself as a key (no idea why it may be used except of a DoS attack)
-    HashMap f = new HashMap();
+    LinkedHashMap f = new LinkedHashMap();
     f.put(f, "a");
     f.put("g", root);
 


### PR DESCRIPTION
## Description

Fixed the flaky test `parseManyAliasesForCollections` `referencesWithRecursiveKeysNotAllowedByDefault` inside the `ReferencesTest` class.
Fixed the flaky test `loadRecursiveMap2` inside the `RecursiveMapTest` class.
Fixed the flaky test `dumpToStringTwice` inside the `DumpToStringTest` class.


### Root Cause
The tests `parseManyAliasesForCollections` `referencesWithRecursiveKeysNotAllowedByDefault` `loadRecursiveMap2`  `dumpToStringTwice` has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. These tests failed because they tried to pass a java `HashMap` to the `dumpToString` method which will dump all the instances from the iterator into a stream with every instance in a given object document. 

https://github.com/snakeyaml/snakeyaml-engine/blob/9d2bca887ad1be7575bae2e427d074e2c49ff109/src/main/java/org/snakeyaml/engine/v2/api/Dump.java#L116-L120
However, Java `HashMap` does not guarantee the order of elements inside it, and `dumpToString` will process map structure element by element. Therefore, executing a map with different sequences will generate unexpected results.

To reproduce run:
```
mvn -pl <module_name> edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<test_name>
```

### Fix
Test in this class is fixed by changing `HashMap` to `LinkedHashMap` which can guarantee element order and change the expected result with the correct executing order. 


#### Key changed/added classes in this PR

- `org.snakeyaml.engine.usecases.recursive.RecursiveMapTes`
- `org.snakeyaml.engine.usecases.references.ReferencesTest`
- `org.snakeyaml.engine.usecases.references.ReferencesTest`
- `org.snakeyaml.engine.issues.issue25.DumpToStringTest`
